### PR TITLE
Data pipeline between tasks execution implemented

### DIFF
--- a/task/task.go
+++ b/task/task.go
@@ -25,42 +25,50 @@ var ErrNotChild = errors.New("adding non required child")
 
 var ErrChildAlreadyAdded = errors.New("child already added")
 
-type DoFunc func(payload interface{}) error
+// DoFunc is task payload processing function.
+// If DoFunc returns not nil value and there are no error the value  will be saved in context as value
+// with task.ID as key.
+type DoFunc func(ctx context.Context, payload interface{}) (interface{}, error)
+
+type taskResult struct {
+	id     ID
+	result interface{}
+}
 
 type Task struct {
 	sync.Mutex
-	ID          ID
-	Status      Status
-	Requires    map[ID]bool
-	Payload     interface{}
-	do          DoFunc
-	RequiredFor map[ID]bool
-	waitingID   chan ID
-	notifyIDs   []chan<- ID
+	ID            ID
+	Status        Status
+	Requires      map[ID]bool
+	Payload       interface{}
+	do            DoFunc
+	RequiredFor   map[ID]bool
+	waitingResult chan taskResult
+	notifyResult  []chan<- taskResult
 }
 
-func NewTask(id ID, requires []ID, payload interface{}, execFunc DoFunc) *Task {
+func NewTask(id ID, requires []ID, payload interface{}, doFunc DoFunc) *Task {
 	reqSet := make(map[ID]bool, len(requires))
 	for _, req := range requires {
 		reqSet[req] = true
 	}
-	var waitingID chan ID
+	var waitingID chan taskResult
 	if len(requires) > 0 {
-		waitingID = make(chan ID, len(requires))
+		waitingID = make(chan taskResult, len(requires))
 	}
 	return &Task{
-		ID:          id,
-		Status:      StatusNew,
-		Requires:    reqSet,
-		RequiredFor: make(map[ID]bool),
-		Payload:     payload,
-		do:          execFunc,
-		waitingID:   waitingID,
+		ID:            id,
+		Status:        StatusNew,
+		Requires:      reqSet,
+		RequiredFor:   make(map[ID]bool),
+		Payload:       payload,
+		do:            doFunc,
+		waitingResult: waitingID,
 	}
 }
 
 // AddChild adds child task.
-func (t *Task) AddChild(child Task) error {
+func (t *Task) AddChild(child *Task) error {
 	t.Lock()
 	defer t.Unlock()
 
@@ -73,7 +81,7 @@ func (t *Task) AddChild(child Task) error {
 		return ErrChildAlreadyAdded
 	}
 
-	t.notifyIDs = append(t.notifyIDs, child.waitingID)
+	t.notifyResult = append(t.notifyResult, child.waitingResult)
 	t.RequiredFor[child.ID] = true
 	return nil
 }
@@ -85,15 +93,21 @@ func Exec(ctx context.Context, cancelFunc context.CancelFunc, task *Task) error 
 
 	log.Debugf("Execution of task %q initiated", task.ID)
 
-	if task.waitingID != nil {
+	if task.waitingResult != nil {
 		task.Status = StatusWaiting
 		received := make(map[ID]bool, len(task.Requires))
+
 	loop:
 		for {
 			select {
-			case id := <-task.waitingID:
-				log.Debugf("%v is notified: task %q is finished.", task.ID, id)
-				received[id] = true
+			case res := <-task.waitingResult:
+				log.Debugf("%v is notified: task %q is finished.", task.ID, res.id)
+				received[res.id] = true
+
+				if res.result != nil {
+					log.Debugf("Adding task %v result into context", res.id)
+					ctx = context.WithValue(ctx, res.id, res.result)
+				}
 
 				// Checking if all requirements are satisfied
 				if len(received) == len(task.Requires) {
@@ -111,7 +125,9 @@ func Exec(ctx context.Context, cancelFunc context.CancelFunc, task *Task) error 
 
 	log.Debugf("Running task %q", task.ID)
 	task.Status = StatusRunning
-	if err := task.do(task.Payload); err != nil {
+
+	res, err := task.do(ctx, task.Payload)
+	if err != nil {
 		log.Errorf("Task %q failed: %v", task.ID, err)
 		task.Status = StatusError
 		log.Debugf("Execution cancellation initiated from task %q", task.ID)
@@ -122,9 +138,9 @@ func Exec(ctx context.Context, cancelFunc context.CancelFunc, task *Task) error 
 	task.Status = StatusReady
 	log.Debugf("Task %q is ready", task.ID)
 
-	for _, notifCh := range task.notifyIDs {
+	for _, notifCh := range task.notifyResult {
 		log.Debugf("Sending notification about %v is finished to %v", task.ID, notifCh)
-		notifCh <- task.ID
+		notifCh <- taskResult{task.ID, res}
 	}
 	log.Infof("Task %q execution is finished", task.ID)
 


### PR DESCRIPTION
Context with value is used for passing data between tasks executions.
'lock by value' warning fixed in AddChild.